### PR TITLE
Fix Azure Table Entity Retrieval Parameter Order in ImageLikeService

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -29,7 +29,7 @@ namespace NETPhotoGallery.Services
         {
             try
             {
-                var response = await _tableClient.GetEntityAsync<ImageLike>(imageId, "images");
+                var response = await _tableClient.GetEntityAsync<ImageLike>("images", imageId);
                 return response.Value.LikeCount;
             }
             catch (Azure.RequestFailedException ex)


### PR DESCRIPTION
### Root Cause
The error "The specified resource does not exist" was occurring due to incorrect parameter order in calls to the `GetEntityAsync` method within the `ImageLikeService` class. The application was mistakenly using the parameters as (rowKey, partitionKey) instead of (partitionKey, rowKey) when attempting to access entities in Azure Tables.

### Changes Made
- **Corrected Parameter Order:** Updated the parameter order in the `GetEntityAsync` method call within the `GetLikesAsync` method of `ImageLikeService.cs` to follow (partitionKey, rowKey).

### How the Fix Addresses the Issue
By correcting the parameter order, the application accurately retrieves the desired entities from Azure Tables, resolving the "The specified resource does not exist" exception. This ensures that the `GetLikesAsync` method functions as intended by properly accessing and returning the like count for images.

### Additional Context
- No changes were needed for similar methods such as `AddLikeAsync`, which already had the correct parameter order.
- Developers should ensure that all data access follows the correct parameter conventions for Azure Tables to avoid similar issues.

Closes #44 