### PR TITLE
Fix 'Not Implemented' Error by Correcting Azure Table Storage Query Syntax

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
## Root Cause
The 'Not Implemented' error (status code 501) was traced to an incorrect query filter syntax in the `GetAllLikesAsync` method of `ImageLikeService.cs`. The syntax error occurred due to missing quotes around the string value 'images' in the PartitionKey filter of an Azure Table Storage query. The erroneous filter was: `PartitionKey eq images`.

## Changes Made
- The query filter expression in `GetAllLikesAsync` has been corrected to include single quotes around the string value 'images': `PartitionKey eq 'images'`.

## How the Fix Addresses the Issue
Adding single quotes around string values is a requirement of the Azure Table Storage query syntax. This fix ensures the query is processed correctly by Azure Table Storage, thereby resolving the 'Not Implemented' error.

## Additional Context
This fix directly addresses the improper syntax that led to the error and aligns with Azure's expectations for processing string values in queries. Future implementations querying similar services should ensure compliance with the required syntax to prevent similar issues.

Closes: #61