### PR TITLE
Fix 'NotImplemented' Error in Azure Table Storage Query by Correcting Filter Syntax

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause:
The 'NotImplemented' exception was triggered due to an incorrect query filter syntax in the Azure Data Tables library. The error originated from the 'GetAllLikesAsync' method of the `ImageLikeService` class, specifically when querying Azure Table Storage for entities. The filter syntax `PartitionKey eq images` was invalid as it lacked quotes around the string 'images'.

### Changes Made:
- Corrected the filter expression by enclosing the string literal 'images' with single quotes in the `GetAllLikesAsync` method. The updated filter is now `PartitionKey eq 'images'`.

### How the Fix Addresses the Issue:
The Azure Table Storage query syntax requires string literals to be enclosed in single quotes. By adding quotes around 'images', the query is modified to conform to Azure Table Storage's expected syntax, thereby preventing the 'NotImplemented' exception and allowing the query to execute successfully.

### Additional Context:
Developers should be mindful of Azure Table Storage's query syntax requirements. Any similar operations involving string literals within queries must ensure proper quoting to avoid syntax-related exceptions.

Closes: #71