### PR TITLE
Fix Azure Table Storage Query by Enclosing PartitionKey in Single Quotes

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause

The issue was that the Azure Table Storage query in the `GetAllLikesAsync` method of the `ImageLikeService` class used an incorrect filter string. The error message 'The requested operation is not implemented on the specified resource' with status '501 (Not Implemented)' indicated that the filter syntax was not properly formatted, specifically due to missing single quotes around the string value in the filter expression.

### Changes Made

- Modified the Azure Table Storage query in `ImageLikeService.cs` to enclose the `PartitionKey` value within single quotes. The filter was changed from `filter: $"PartitionKey eq images"` to `filter: $"PartitionKey eq 'images'"`.

### How the Fix Addresses the Issue

Enclosing string values in single quotes is required by the Azure Table Storage query syntax. By correcting the filter expression to `PartitionKey eq 'images'`, the query is compliant with the syntax requirements, allowing Azure Table Storage to recognize and implement the requested operation properly.

### Additional Context

Developers should ensure that any string values in Azure Table Storage query filters are enclosed in single quotes to prevent similar implementation issues. This fix should be tested to confirm that the query now executes correctly without raising a 501 error.

Closes: #73