### PR TITLE
Fix Azure Table Storage Query Syntax in GetAllLikesAsync

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause
The exception encountered was due to an incorrect OData filter string in the `GetAllLikesAsync` method of `ImageLikeService`. The filter syntax for querying Azure Table Storage was improperly formatted, resulting in a 'NotImplemented' error with status code 501.

### Changes Made
In the `ImageLikeService` class, the filter string within the query operation was corrected. The initial query `filter: $"PartitionKey eq images"` was missing single quotes around the string 'images'. The fix involved updating the code to `filter: $"PartitionKey eq 'images'"`, which aligns with the expected OData filter syntax for Azure Table Storage.

### How the Fix Addresses the Issue
By adding single quotes around the `PartitionKey` value, the query string now complies with OData standards, allowing the Azure Table Storage to process the request correctly. This change resolves the 'NotImplemented' error and enables successful querying of the storage.

### Additional Context
Developers should ensure all OData filter strings are properly formatted with single quotes around string literals to avoid similar issues in future interactions with Azure Table Storage. Additionally, this fix does not impact any other parts of the application as it is localized to the specific query syntax within the `GetAllLikesAsync` method.

Closes: #75