### PR TITLE
Fix Azure Table Storage Query Filter Syntax in ImageLikeService

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause
The application was encountering an error when trying to interact with Azure Table Storage. The error message 'The requested operation is not implemented on the specified resource.' was caused by an incorrect query filter syntax in the `GetAllLikesAsync` method of the `ImageLikeService` class. Specifically, the filter expression `"PartitionKey eq images"` was missing quotes around the string value `images`.

### Changes Made
- Updated the filter expression in the `GetAllLikesAsync` method to include single quotes around the string value `images`. The corrected filter syntax is now `"PartitionKey eq 'images'"`.

### How the Fix Addresses the Issue
By enclosing the string `images` with single quotes, the query filter syntax conforms to the requirements of Azure Table Storage. This allows the operation to be recognized and executed correctly, thereby resolving the error and allowing successful data retrieval.

### Additional Context
This fix ensures proper querying of the Azure Table Storage within the `ImageLikeService` and helps maintain seamless data operations in the application. Developers should ensure that any future string literals in Azure Table Storage queries are enclosed in single quotes to avoid similar issues.

Closes: #78