### PR TITLE
Fix 'ResourceNotFound' by Correcting Partition and Row Key Order in GetLikesAsync

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -29,7 +29,7 @@ namespace NETPhotoGallery.Services
         {
             try
             {
-                var response = await _tableClient.GetEntityAsync<ImageLike>(imageId, "images");
+                var response = await _tableClient.GetEntityAsync<ImageLike>("images", imageId);
                 return response.Value.LikeCount;
             }
             catch (Azure.RequestFailedException ex)


### PR DESCRIPTION
### Root Cause
The 'ResourceNotFound' exception was triggered due to an incorrect order of partition and row keys in the `GetEntityAsync` call within the `GetLikesAsync` method of the `ImageLikeService.cs` file. The method was attempting to access a resource using a mismatched key order, resulting in the failed attempt to retrieve data.

### Changes Made
- The parameters passed to `GetEntityAsync` in the `GetLikesAsync` method were reordered to use the correct sequence of partition key and row key. Initially, the partition key was the image ID, and the row key was "images". This order has been swapped to match the correct configuration where the partition key is "images" and the row key is the image ID.

### How the Fix Addresses the Issue
By ensuring the order of keys in the `GetEntityAsync` call aligns with how the data is stored, the method can now successfully retrieve the intended resource. This prevents the 'ResourceNotFound' exception and allows the `GetLikesAsync` function to function correctly, returning the accurate like count for images.

### Additional Context
Developers should ensure consistency in key ordering between methods that store and access data, such as `AddLikeAsync` and `GetLikesAsync`, to prevent similar issues in the future. This change ensures that data retrieval aligns with the initial storage logic, maintaining system integrity and operational consistency.

Closes: #80