### PR TITLE
Fix Azure Table Storage Query Error in ImageLikeService

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause
The issue stemmed from an improperly formatted OData filter in the `GetAllLikesAsync` method of the `ImageLikeService` class. The Azure.Table.Storage service requires that string literals in OData query filters be enclosed in quotes. The absence of quotes around the 'images' string led to a `Status: 501 (Not Implemented)` error.

### Changes Made
- Updated the filter in the `QueryAsync` method call from:
  ```csharp
  filter: $"PartitionKey eq images"
  ```
  to:
  ```csharp
  filter: $"PartitionKey eq 'images'"
  ```
- This addition of single quotes around the string literal 'images' adheres to the required OData filter syntax.

### How the Fix Addresses the Issue
By ensuring the proper syntax for the filter string, the query can now be executed correctly by Azure Table Storage, thus resolving the `Not Implemented` error that was occurring due to the previous misuse of the OData syntax.

### Additional Context
Developers should be aware of the importance of adhering to OData query syntax requirements when interfacing with Azure services to prevent similar errors. This fix should now allow `GetAllLikesAsync` to correctly retrieve likes associated with images in the table storage, as intended.

Closes: #83