### PR TITLE
Fix NotImplemented Error in Azure Table Storage Query by Correcting Filter Syntax

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
This pull request addresses a `NotImplemented` exception in the `GetAllLikesAsync` method of the `ImageLikeService.cs` file, which was caused by an incorrect use of Azure Table Storage API syntax.

### Root Cause
The root cause of the issue was an incorrect query filter syntax in the `ImageLikeService.cs` file. The filter string used to query Azure Table Storage was missing quotes around the string value `images`. Azure Table Storage requires string values in filter queries to be enclosed in single quotes, and the absence of these quotes led to the API rejecting the request.

### Changes Made
- **Code Update**: In `ImageLikeService.cs`, modified the filter string in the `GetAllLikesAsync` method to include single quotes around the string value, changing from `filter: $"PartitionKey eq images"` to `filter: $"PartitionKey eq 'images'"`.

### How the Fix Addresses the Issue
The fix ensures that the filter syntax adheres to the correct Azure Table Storage query format by enclosing the string value in single quotes. This change allows the query to be correctly interpreted by Azure Table Storage API, thereby resolving the `NotImplemented` exception.

### Additional Context
Developers should be aware that Azure Table Storage queries require string values within the filter to be surrounded by single quotes to be syntactically correct. This fix was committed with ID `33f7be1` and ensures that future operations involving similar queries are handled appropriately, preventing potential issues with unsupported operations.

Closes: #85