### PR TITLE
Fix Azure Table Storage Query Parameter Order in GetLikesAsync Method

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -29,7 +29,7 @@ namespace NETPhotoGallery.Services
         {
             try
             {
-                var response = await _tableClient.GetEntityAsync<ImageLike>(imageId, "images");
+                var response = await _tableClient.GetEntityAsync<ImageLike>("images", imageId);
                 return response.Value.LikeCount;
             }
             catch (Azure.RequestFailedException ex)


### PR DESCRIPTION
This pull request addresses a critical issue causing the error 'The specified resource does not exist' in the `GetLikesAsync` method within `ImageLikeService.cs`.

### Root Cause
The error was due to incorrect parameter order when querying Azure Table Storage using the `GetEntityAsync` method. The partition key and row key were erroneously swapped, resulting in failed entity retrieval attempts for image likes.

### Changes Made
1. Corrected the parameter order in the `GetEntityAsync` method call:
    - Set the first parameter to the partition key: "images".
    - Set the second parameter to the row key: `imageId`.

### How the Fix Addresses the Issue
By swapping the parameters to match the correct partition and row key order, entities are successfully retrieved from Azure Table Storage, preventing exceptions and allowing the method to return the accurate like count for the queried image.

### Additional Context
- The parameter correction aligns with how data is structured in the `AddLikeAsync` method.
- A default value of 0 is returned if an `Azure.RequestFailedException` is caught, ensuring robustness for non-existent resources.

This fix will prevent the `GetLikesAsync` method from failing due to incorrect resource queries and improve overall application stability.

Closes: #88