### PR TITLE
Fix Azure Table Storage Filter Syntax in GetAllLikesAsync Method

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause
The root cause of the 'NotImplemented' error leading to a status code of 501 was an incorrect filter expression syntax used in Azure Table Storage queries within the `GetAllLikesAsync` method in `ImageLikeService.cs`. Specifically, string values in Azure Table Storage filter expressions were not enclosed in single quotes, which is mandatory for the query to be recognized and executed properly by Azure Table Storage.

### Changes Made
- In `ImageLikeService.cs`, updated the `filter` parameter of the `QueryAsync` method from using `PartitionKey eq images` to `PartitionKey eq 'images'`, ensuring that the string value 'images' is correctly encapsulated in single quotes.

### How the Fix Addresses the Issue
By enclosing the string in single quotes, the filter expression now adheres to the correct syntax for Azure Table Storage. This allows it to be recognized as a valid operation by the Azure Tables service, hence resolving the 501 'NotImplemented' error and enabling the query to execute successfully.

### Additional Context
This change will ensure compatibility with Azure Table Storage querying conventions and help avoid errors related to unsupported operations due to syntax issues. Developers should verify any other Azure Table Storage queries within the application to ensure similar adherence to syntax requirements to prevent any further issues.

Closes: #90