### PR TITLE
Fix NotImplemented Error in GetAllLikesAsync by Correcting Azure Query Syntax

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause
The exception was caused by incorrect query syntax in the `GetAllLikesAsync` method of `ImageLikeService.cs`. The error message and stack trace indicated a `NotImplemented` error with Azure Table Storage, pointing to line 47 where the query was missing proper quoting.

### Changes Made
In the `GetAllLikesAsync` method, the query filter syntax for Azure Table Storage was corrected by adding single quotes around the string value `'images'`. The revised filter expression now reads:
```csharp
var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
```

### How the Fix Addresses the Issue
Azure Table Storage queries require string values in filters to be enclosed in single quotes. By adding these quotes, the query can correctly execute without encountering a `NotImplemented` error, allowing it to return the expected results from Azure.

### Additional Context
This correction ensures compliance with Azure Table Storage's query syntax, which is crucial for successful interaction with Azure resources. Developers should ensure that all string values in query expressions are properly quoted to prevent similar issues in the future.
```

Closes: #92