### PR TITLE
Fix QueryEntitiesAsync 'Not Implemented' Error by Correcting Filter Syntax in Azure Table Query

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,7 +42,7 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
             await foreach (var like in queryResults)
             {


### PR DESCRIPTION
### Root Cause
The application encountered a 'Not Implemented' exception when querying Azure Table using the `QueryEntitiesAsync` method. This issue arose from an improperly constructed filter expression in the `GetAllLikesAsync` method of the `ImageLikeService` class. Specifically, the filter string used for querying did not include the required quotes around the string literal `images`, violating the expected syntax for Azure Table Storage queries.

### Changes Made
Updated `ImageLikeService.cs`:
- Corrected the filter expression in the `GetAllLikesAsync` method by adding single quotes around the `PartitionKey` string value.

```csharp
var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
```

### How the Fix Addresses the Issue
By enclosing the `images` string literal within single quotes, the query string now adheres to the OData filter syntax requirements of the Azure Table Storage API. This resolves the `Not Implemented` exception by ensuring the query is properly formatted and executable by the `QueryEntitiesAsync` method.

### Additional Context
Developers should remember that OData filter strings require single quotes around string literals. This syntax is crucial for string comparison operations when working with Azure Table queries. Future queries should be carefully checked to ensure compliance with OData standards to prevent similar issues.

Closes: #94