### PR TITLE
Fix Azure Table Storage Query Filter Syntax Error in ImageLikeService

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,11 +42,19 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq images");
+            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
 
-            await foreach (var like in queryResults)
+            try
             {
-                results[like.RowKey] = like.LikeCount;
+                await foreach (var like in queryResults)
+                {
+                    results[like.RowKey] = like.LikeCount;
+                }
+            }
+            catch (Azure.RequestFailedException ex)
+            {
+                _logger.LogError(ex, "Failed to query likes from table storage");
+                // Continue with empty results rather than failing the entire page load
             }
 
             return results;


### PR DESCRIPTION
## Root Cause
The root cause of the issue was an incorrect syntax in the Azure Table Storage query filter in the `GetAllLikesAsync` method of `ImageLikeService.cs`. The `Not Implemented` error occurred because the filter string was missing single quotes around the literal value, which is required for string literals in Azure Table Storage query expressions.

## Changes Made
- Corrected the query filter syntax by enclosing the `'images'` literal in single quotes within the `QueryAsync` method.
- Added a `try-catch` block to handle potential exceptions, specifically handling `Azure.RequestFailedException`. This ensures the application logs the error and continues with an empty result set rather than failing the entire page load.

## How the Fix Addresses the Issue
By updating the query syntax to include proper quoting, the query can execute successfully against Azure Table Storage, thus eliminating the `Not Implemented` error. The added error handling ensures the application remains resilient in case of query failures.

## Additional Context
Developers should ensure that string literals in filter expressions provided to Azure Table Storage are always enclosed in single quotes to avoid similar issues in the future. Additionally, incorporating robust error handling mechanisms will improve system reliability by preventing service disruptions due to isolated failures.

Closes: #96