### PR TITLE
Fix: Correct Azure Table entity retrieval parameters in GetLikesAsync method

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -29,7 +29,7 @@ namespace NETPhotoGallery.Services
         {
             try
             {
-                var response = await _tableClient.GetEntityAsync<ImageLike>(imageId, "images");
+                var response = await _tableClient.GetEntityAsync<ImageLike>("images", imageId);
                 return response.Value.LikeCount;
             }
             catch (Azure.RequestFailedException ex)


### PR DESCRIPTION
### Root Cause
The `ResourceNotFound` error with HTTP status 404 was occurring because the parameters for the partition key and row key were reversed in the call to `GetEntityAsync` within the `GetLikesAsync` method in the `ImageLikeService.cs` file. This led to an attempt to access a non-existent resource in Azure Tables, as the code was improperly structured.

### Changes Made
- Corrected the parameter order in the `GetEntityAsync` method call. The partition key and row key are now provided in the correct order: first the partition key (`"images"`) and then the row key (`imageId`).

### How the Fix Addresses the Issue
- By ensuring the parameters are correctly ordered, the code can now properly retrieve the intended resource from Azure Tables, preventing the `ResourceNotFound` error and allowing for successful execution of the `GetLikesAsync` method.

### Additional Context
- Developers should be mindful of parameter order when working with Azure Table operations. Incorrect parameter positioning can lead to significant errors such as resource retrieval failures.
- No changes needed outside the `GetLikesAsync` method in the `ImageLikeService.cs` file for this fix.

Closes: #98