### PR TITLE
Fix stream disposal issue in AzureBlobService to prevent premature object disposal

### DIFF
--- a/src/net-photo-gallery/Services/AzureBlobService.cs
+++ b/src/net-photo-gallery/Services/AzureBlobService.cs
@@ -63,12 +63,13 @@ namespace NETPhotoGallery.Services
 			for (int i = 0; i < files.Count; i++)
 			{
 				var blob = blobContainer.GetBlobClient(GetRandomBlobName(files[i].FileName));
-				using (var stream = files[i].OpenReadStream())
+                using var stream = files[i].OpenReadStream();
+				if (i > 0)
 				{
-					await blob.UploadAsync(stream);
-
+					stream.Close();
 				}
-			}
+                await blob.UploadAsync(stream);
+            }
 		}
 
 		/// <summary> 

--- a/src/net-photo-gallery/Services/AzureBlobService.cs
+++ b/src/net-photo-gallery/Services/AzureBlobService.cs
@@ -63,13 +63,11 @@ namespace NETPhotoGallery.Services
 			for (int i = 0; i < files.Count; i++)
 			{
 				var blob = blobContainer.GetBlobClient(GetRandomBlobName(files[i].FileName));
-                using var stream = files[i].OpenReadStream();
-				if (i > 0)
+				using (var stream = files[i].OpenReadStream())
 				{
-					stream.Close();
+					await blob.UploadAsync(stream);
 				}
-                await blob.UploadAsync(stream);
-            }
+			}
 		}
 
 		/// <summary> 


### PR DESCRIPTION
### Root Cause
The exception "Cannot access a disposed object. Object name: 'System.String'" was caused by premature disposal of a stream when uploading files to Azure Blob Storage. In the `AzureBlobService.cs`, each stream opened for file upload was being closed prematurely in a loop due to incorrect handling within a conditional statement.

### Changes Made
- Removed the conditional statement that prematurely closed streams for all files except the first one.
- Introduced a proper `using` block for each file to ensure that the stream is disposed of only after the upload is complete.

### How the Fix Addresses the Issue
The fix ensures that each stream remains open for the duration of its corresponding upload, preventing the premature disposal error. By using a `using` block, each stream is properly managed and closed only after the upload operation, in adherence to best practices for resource management.

### Additional Context
Developers should ensure that all streams are correctly managed when dealing with file uploads to avoid similar resource disposal issues. The use of `using` blocks not only prevents premature closing but also simplifies the code by automatically handling disposal. Future code reviews should include checks for such disposal patterns to maintain resource integrity and application stability.

Closes: #100