### PR TITLE
Fix InvalidOperationException in HomeController Statistics Method by Handling Empty Collections

### DIFF
--- a/src/net-photo-gallery/Controllers/HomeController.cs
+++ b/src/net-photo-gallery/Controllers/HomeController.cs
@@ -145,7 +145,7 @@ namespace NETPhotoGallery.Controllers
                 int totalImages = blobs.Count;
                 long totalDiskSpace = blobs.Sum(b => b.Size);
                 int totalLikes = likesMap.Values.Sum();
-                double averageImageSize = blobs.Average(b => (double)b.Size);
+                double averageImageSize = blobs.Any() ? blobs.Average(b => (double)b.Size) : 0;
 
                 // Calculate uploads per day for last 30 days
                 var today = DateTime.UtcNow.Date;


### PR DESCRIPTION
### Root Cause
The `System.InvalidOperationException` occurring in the `HomeController` arises from calling the `System.Linq.Enumerable.Average` method on an empty collection within the `Statistics` method. This error specifically occurs at line 148 in `HomeController.cs`, where an attempt is made to compute the average size of images without first verifying if the collection, `blobs`, contains any elements. Consequently, when the collection is devoid of elements, the exception is thrown.

### Changes Made
The code has been modified to include a condition that checks whether the `blobs` collection contains elements before attempting to calculate the average. This is achieved using the `.Any()` method:
```csharp
double averageImageSize = blobs.Any() ? blobs.Average(b => (double)b.Size) : 0;
```
This alteration ensures that in scenarios where the `blobs` collection is empty, `averageImageSize` defaults to 0 rather than triggering an exception.

### How the Fix Addresses the Issue
By incorporating a check for the collection's non-emptiness before invoking `Average()`, we now safely handle cases with no images, thereby preventing the `InvalidOperationException`. This fix ensures stability and reliable execution of the `Statistics` method under all circumstances.

### Additional Context
Developers should be mindful of operations on collections, especially when methods like `Average()` are concerned, which assume non-empty inputs. Implementing checks or default behaviors can prevent similar exceptions and enhance robustness.

Closes: #102