### PR TITLE
Fix InvalidOperationException in HomeController's Statistics Method by Handling Empty Sequence

### DIFF
--- a/src/net-photo-gallery/Controllers/HomeController.cs
+++ b/src/net-photo-gallery/Controllers/HomeController.cs
@@ -145,7 +145,7 @@ namespace NETPhotoGallery.Controllers
                 int totalImages = blobs.Count;
                 long totalDiskSpace = blobs.Sum(b => b.Size);
                 int totalLikes = likesMap.Values.Sum();
-                double averageImageSize = blobs.Average(b => (double)b.Size);
+                double averageImageSize = blobs.Any() ? blobs.Average(b => (double)b.Size) : 0;
 
                 // Calculate uploads per day for last 30 days
                 var today = DateTime.UtcNow.Date;


### PR DESCRIPTION
The root cause of the error was an `InvalidOperationException` caused by calling the `Average` method on an empty sequence in the `Statistics` method of `NETPhotoGallery.Controllers.HomeController`. This exception occurred when there were no blobs (images) in the system, leading to an attempt to compute an average from an empty collection.

To fix this, the code was updated in `HomeController.cs` at line 148 to include a check using the `Any()` method to verify if the `blobs` collection has any elements before calculating the average image size. If the collection is empty, the code now returns 0 as the average image size, preventing the exception from being thrown.

This change addresses the issue by ensuring that the `Average` method is only called on a collection with elements, thereby avoiding the `InvalidOperationException`. Developers should be aware that this solution assumes a default average size of 0 for an empty collection, which should be appropriate in the context of the application's requirements.

Closes: #104