### PR TITLE
Fix: Handle Table Not Found Error in GetAllLikesAsync Method

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -42,11 +42,23 @@ namespace NETPhotoGallery.Services
         public async Task<Dictionary<string, int>> GetAllLikesAsync()
         {
             var results = new Dictionary<string, int>();
-            var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
-
-            await foreach (var like in queryResults)
+            try
             {
-                results[like.RowKey] = like.LikeCount;
+                var queryResults = _tableClient.QueryAsync<ImageLike>(filter: $"PartitionKey eq 'images'");
+
+                await foreach (var like in queryResults)
+                {
+                    results[like.RowKey] = like.LikeCount;
+                }
+            }
+            catch (Azure.RequestFailedException ex) when (ex.ErrorCode == "TableNotFound")
+            {
+                _logger.LogWarning("Table {TableName} not found. Creating it now.", TableName);
+                await _tableClient.CreateIfNotExistsAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving likes from table {TableName}", TableName);
             }
 
             return results;


### PR DESCRIPTION
### Root Cause:
The exception `'The table specified does not exist'` was occurring in the `GetAllLikesAsync` method of the `ImageLikeService.cs` file. This error arose because the method attempted to query a non-existent table in Azure Table Storage. The table was not being created prior to certain queries accessing it.

### Changes Made:
- Implemented error handling in the `GetAllLikesAsync` method to catch the specific `Azure.RequestFailedException` when the error code is `"TableNotFound"`.
- Introduced a `try-catch` block that catches this exception, logs a warning message, and initiates the creation of the table if it doesn't already exist using the `CreateIfNotExistsAsync` method.
- Added a general exception catch to log any other potential errors during the query execution.

### How the Fix Addresses the Issue:
By adding a handler for the `TableNotFound` error, the service will now attempt to create the missing table dynamically upon encountering this specific error. This prevents the method from failing and allows the execution to proceed smoothly, ensuring that table creation is accounted for during runtime, without prior existence assumptions.

### Additional Context:
- The changes ensure robustness by logging appropriate messages for both specific table-related issues and broader exceptions that could arise, aiding in easier troubleshooting and monitoring of the service's behavior.
- This fix assumes that table creation is permitted at runtime and that such creation does not have concurrent access issues.

Closes: #108