### PR TITLE
Fix incorrect parameter order in GetEntityAsync call in ImageLikeService.cs

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -29,7 +29,7 @@ namespace NETPhotoGallery.Services
         {
             try
             {
-                var response = await _tableClient.GetEntityAsync<ImageLike>(imageId, "images");
+                var response = await _tableClient.GetEntityAsync<ImageLike>("images", imageId);
                 return response.Value.LikeCount;
             }
             catch (Azure.RequestFailedException ex)


### PR DESCRIPTION
The issue was identified in the `GetLikesAsync` method within `ImageLikeService.cs`, where a RequestFailedException was thrown due to incorrect parameters passed to the `GetEntityAsync` method. This misconfiguration led to errors when attempting to access a non-existent resource, resulting in the message 'The specified resource does not exist'.

**Root Cause:**
In the `GetEntityAsync` method, the parameters for partition key and row key were swapped. The method call incorrectly listed `imageId` as the partition key and `"images"` as the row key.

**Changes Made:**
The parameters in `GetEntityAsync` call were corrected by swapping the order: the partition key is now `"images"` and the row key is `imageId`.

**How the Fix Addresses the Issue:**
By properly ordering the parameters, the service can accurately retrieve the image likes from the table, avoiding the exception by pointing to the correct resource path identifiers in Azure Table Storage.

**Additional Context:**
This fix aligns the parameter order in the `GetLikesAsync` method with how data is stored using the `AddLikeAsync` method, ensuring consistency and accurate data retrieval across the service. This ensures that similar issues do not arise in future operations that interact with the Azure Table.

Closes: #112