### PR TITLE
Fix Azure TableNotFound Exception by Awaiting Table Creation in ImageLikeService

### DIFF
--- a/src/net-photo-gallery/Services/ImageLikeService.cs
+++ b/src/net-photo-gallery/Services/ImageLikeService.cs
@@ -21,7 +21,7 @@ namespace NETPhotoGallery.Services
             _logger = logger;
             var connectionString = configuration.GetValue<string>("StorageConnectionString");
             var tableServiceClient = new TableServiceClient(connectionString);
-            tableServiceClient.CreateTableIfNotExists(TableName);
+            tableServiceClient.CreateTableIfNotExistsAsync(TableName).GetAwaiter().GetResult();
             _tableClient = tableServiceClient.GetTableClient(TableName);
         }
 


### PR DESCRIPTION
This pull request addresses the 'TableNotFound' exception that occurs due to premature table usage before its creation operation is completed in Azure Table Storage. The root cause of the issue was found in the `ImageLikeService.cs` file, specifically at line 47, where the `CreateTableIfNotExists` method was called without awaiting its completion. This led to attempts to access a table that had not yet been created.

### Changes Made:
- Updated `ImageLikeService.cs` to use the asynchronous `CreateTableIfNotExistsAsync` method and properly await its completion with `.GetAwaiter().GetResult()`. 
- This ensures that the table creation is completed before any subsequent operations attempt to use the table, thereby preventing the 'TableNotFound' exception.

### Context for Developers:
- The fix was applied to ensure the Azure table creation operation completes successfully before any other operations are executed on the table. This change is crucial for preventing runtime errors related to nonexistent tables.
- No changes were needed in the `HomeController.cs` file as the issue primarily stemmed from how the table client was instantiated in the `ImageLikeService.cs`.

This modification should resolve the exception and improve the stability of services dependent on Azure Table Storage interactions.

Closes: #114